### PR TITLE
Added straightening rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ function markdownTable(table, options) {
 
     index = -1;
 
-    while (++index < cellCount) {
+    while (settings.straighten !== false && ++index < cellCount) {
       value = cells[index];
 
       position = sizes[index] - (calculateStringLength(value) || 0);
@@ -204,11 +204,24 @@ function markdownTable(table, options) {
     rule = [];
 
     while (++index < cellCount) {
+      /* When `straighten` is false, make the rule the same size as the first row. */
+      if (settings.straighten === false) {
+        value = table[0][index];
+        if (value === null || value === undefined) {
+          value = '';
+        } else {
+          value = String(value);
+        }
+        spacing = value.length > 3 ? value.length : 3;
+      } else {
+        spacing = sizes[index];
+      }
+
       align = alignment[index];
 
       /* When `align` is left, don't add colons. */
       value = align === RIGHT || align === NULL ? DASH : COLON;
-      value += pad(sizes[index] - 2, DASH);
+      value += pad(spacing - 2, DASH);
       value += align !== LEFT && align !== NULL ? COLON : DASH;
 
       rule[index] = value;

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function markdownTable(table, options) {
 
     index = -1;
 
-    if (settings.straighten !== false) {
+    if (settings.pad !== false) {
       while (++index < cellCount) {
         value = cells[index];
 
@@ -203,8 +203,8 @@ function markdownTable(table, options) {
     rule = [];
 
     while (++index < cellCount) {
-      /* When `straighten` is false, make the rule the same size as the first row. */
-      if (settings.straighten === false) {
+      /* When `pad` is false, make the rule the same size as the first row. */
+      if (settings.pad === false) {
         value = table[0][index];
         spacing = calculateStringLength(stringify(value));
         spacing = spacing > MIN_CELL_SIZE ? spacing : MIN_CELL_SIZE;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var DOT = '.';
 var NULL = '';
 
 var ALLIGNMENT = [LEFT, RIGHT, CENTER, DOT, NULL];
+var MIN_CELL_SIZE = 3;
 
 /* Characters. */
 var COLON = ':';
@@ -75,7 +76,7 @@ function markdownTable(table, options) {
       position = row[index] ? dotindex(row[index]) : null;
 
       if (!sizes[index]) {
-        sizes[index] = 3;
+        sizes[index] = MIN_CELL_SIZE;
       }
 
       if (position > sizes[index]) {
@@ -117,11 +118,7 @@ function markdownTable(table, options) {
     while (++index < cellCount) {
       value = row[index];
 
-      if (value === null || value === undefined) {
-        value = '';
-      } else {
-        value = String(value);
-      }
+      value = stringify(value);
 
       if (alignment[index] === DOT) {
         position = dotindex(value);
@@ -151,7 +148,7 @@ function markdownTable(table, options) {
       value = cells[index];
 
       if (!sizes[index]) {
-        sizes[index] = 3;
+        sizes[index] = MIN_CELL_SIZE;
       }
 
       size = calculateStringLength(value);
@@ -169,31 +166,33 @@ function markdownTable(table, options) {
 
     index = -1;
 
-    while (settings.straighten !== false && ++index < cellCount) {
-      value = cells[index];
+    if (settings.straighten !== false) {
+      while (++index < cellCount) {
+        value = cells[index];
 
-      position = sizes[index] - (calculateStringLength(value) || 0);
-      spacing = pad(position);
+        position = sizes[index] - (calculateStringLength(value) || 0);
+        spacing = pad(position);
 
-      if (alignment[index] === RIGHT || alignment[index] === DOT) {
-        value = spacing + value;
-      } else if (alignment[index] === CENTER) {
-        position /= 2;
+        if (alignment[index] === RIGHT || alignment[index] === DOT) {
+          value = spacing + value;
+        } else if (alignment[index] === CENTER) {
+          position /= 2;
 
-        if (position % 1 === 0) {
-          before = position;
-          after = position;
+          if (position % 1 === 0) {
+            before = position;
+            after = position;
+          } else {
+            before = position + 0.5;
+            after = position - 0.5;
+          }
+
+          value = pad(before) + value + pad(after);
         } else {
-          before = position + 0.5;
-          after = position - 0.5;
+          value += spacing;
         }
 
-        value = pad(before) + value + pad(after);
-      } else {
-        value += spacing;
+        cells[index] = value;
       }
-
-      cells[index] = value;
     }
 
     rows[rowIndex] = cells.join(delimiter);
@@ -207,12 +206,8 @@ function markdownTable(table, options) {
       /* When `straighten` is false, make the rule the same size as the first row. */
       if (settings.straighten === false) {
         value = table[0][index];
-        if (value === null || value === undefined) {
-          value = '';
-        } else {
-          value = String(value);
-        }
-        spacing = value.length > 3 ? value.length : 3;
+        spacing = calculateStringLength(stringify(value));
+        spacing = spacing > MIN_CELL_SIZE ? spacing : MIN_CELL_SIZE;
       } else {
         spacing = sizes[index];
       }
@@ -231,6 +226,10 @@ function markdownTable(table, options) {
   }
 
   return start + rows.join(end + NEW_LINE + start) + end;
+}
+
+function stringify(value) {
+  return (value === null || value === undefined) ? '' : String(value);
 }
 
 /* Get the length of `value`. */

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "xo": {
     "space": true,
     "rules": {
-      "complexity": "off"
+      "complexity": "off",
+      "max-depth": "off"
     },
     "ignores": [
       "markdown-table.js"

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ The following options are available:
     `s => s.length`)
     — Method to detect the length of a cell (see below).
 *   `options.straighten` (`boolean`, default: `true`)
-    — Whether to make all the table cells the same width. Setting this
+    — Whether to make all the table cells the same width.  Setting this
     to false will cause the table rows to remain staggered.
 
 ### `stringLength(cell)`

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,9 @@ The following options are available:
 *   `options.stringLength` ([`Function`][length], default:
     `s => s.length`)
     — Method to detect the length of a cell (see below).
+*   `options.straighten` (`boolean`, default: `true`)
+    — Whether to make all the table cells the same width. Setting this
+    to false will cause the table rows to remain staggered.
 
 ### `stringLength(cell)`
 

--- a/readme.md
+++ b/readme.md
@@ -116,9 +116,10 @@ The following options are available:
 *   `options.stringLength` ([`Function`][length], default:
     `s => s.length`)
     — Method to detect the length of a cell (see below).
-*   `options.straighten` (`boolean`, default: `true`)
-    — Whether to make all the table cells the same width.  Setting this
-    to false will cause the table rows to remain staggered.
+*   `options.pad` (`boolean`, default: `true`)
+    — Whether to pad the markdown for table cells to make them the same
+    width.  Setting this to false will cause the table rows to
+    remain staggered.
 
 ### `stringLength(cell)`
 

--- a/test.js
+++ b/test.js
@@ -200,14 +200,16 @@ test('table()', function (t) {
   t.equal(
     table([
       ['A'],
-      ['master', '0123456789abcdef'],
-      ['staging', 'fedcba9876543210']
+      ['', '0123456789abcdef'],
+      ['staging', 'fedcba9876543210'],
+      ['develop']
     ], {straighten: false}),
     [
       '| A |  |',
       '| --- | --- |',
-      '| master | 0123456789abcdef |',
-      '| staging | fedcba9876543210 |'
+      '|  | 0123456789abcdef |',
+      '| staging | fedcba9876543210 |',
+      '| develop |  |'
     ].join('\n'),
     'handles short rules and missing elements for tables without straightening'
   );

--- a/test.js
+++ b/test.js
@@ -187,14 +187,14 @@ test('table()', function (t) {
       ['Branch', 'Commit'],
       ['master', '0123456789abcdef'],
       ['staging', 'fedcba9876543210']
-    ], {straighten: false}),
+    ], {pad: false}),
     [
       '| Branch | Commit |',
       '| ------ | ------ |',
       '| master | 0123456789abcdef |',
       '| staging | fedcba9876543210 |'
     ].join('\n'),
-    'should create a table without straightening'
+    'should create a table without padding'
   );
 
   t.equal(
@@ -203,7 +203,7 @@ test('table()', function (t) {
       ['', '0123456789abcdef'],
       ['staging', 'fedcba9876543210'],
       ['develop']
-    ], {straighten: false}),
+    ], {pad: false}),
     [
       '| A |  |',
       '| --- | --- |',
@@ -211,7 +211,7 @@ test('table()', function (t) {
       '| staging | fedcba9876543210 |',
       '| develop |  |'
     ].join('\n'),
-    'handles short rules and missing elements for tables without straightening'
+    'handles short rules and missing elements for tables without padding'
   );
 
   t.test(

--- a/test.js
+++ b/test.js
@@ -182,6 +182,36 @@ test('table()', function (t) {
     'should create a table delimited by `delimiter`'
   );
 
+  t.equal(
+    table([
+      ['Branch', 'Commit'],
+      ['master', '0123456789abcdef'],
+      ['staging', 'fedcba9876543210']
+    ], {straighten: false}),
+    [
+      '| Branch | Commit |',
+      '| ------ | ------ |',
+      '| master | 0123456789abcdef |',
+      '| staging | fedcba9876543210 |'
+    ].join('\n'),
+    'should create a table without straightening'
+  );
+
+  t.equal(
+    table([
+      ['A'],
+      ['master', '0123456789abcdef'],
+      ['staging', 'fedcba9876543210']
+    ], {straighten: false}),
+    [
+      '| A |  |',
+      '| --- | --- |',
+      '| master | 0123456789abcdef |',
+      '| staging | fedcba9876543210 |'
+    ].join('\n'),
+    'handles short rules and missing elements for tables without straightening'
+  );
+
   t.test(
     table([
       ['Branch', 'Commit'],


### PR DESCRIPTION
@wooorm This PR adds a new rule that I've called straightening - which allows you to format tables without any kind of alignment (see the tests for examples).

This style is useful for preventing large diffs during single line changes.

Feel free to make any comments on the code or totally refactor it - I wrote it not knowing your preferences in regards to code-style, performance, etc. but would be keen to get this feature added.