### PR TITLE
Fix calculation of non-ascii string length

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ function serialize(value) {
 }
 
 function defaultStringLength(value) {
-  return value.length
+  return value.length + [...value].filter(ch => ch.codePointAt(0) > 128).length
 }
 
 function toAlignment(value) {


### PR DESCRIPTION
Before:

![2020-06-19 11-40-00 的屏幕截图](https://user-images.githubusercontent.com/1730073/85094877-70d71f00-b222-11ea-8a36-9219d4c21148.png)

After:

![2020-06-19 11-39-42 的屏幕截图](https://user-images.githubusercontent.com/1730073/85094885-759bd300-b222-11ea-954b-43bda43eb7e3.png)
