### PR TITLE
Fix escape pipe char

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ function markdownTable(table, options) {
 }
 
 function serialize(value) {
-  return value === null || value === undefined ? '' : String(value.replace('|', '\\|'))
+  return value === null || value === undefined ? '' : String(value).replace('|', '\\|')
 }
 
 function defaultStringLength(value) {

--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ function markdownTable(table, options) {
 }
 
 function serialize(value) {
-  return value === null || value === undefined ? '' : String(value)
+  return value === null || value === undefined ? '' : String(value.replace('|', '\\|'))
 }
 
 function defaultStringLength(value) {

--- a/test.js
+++ b/test.js
@@ -29,7 +29,8 @@ test('table()', function (t) {
       ['boolean', true],
       ['undefined', undefined],
       ['null', null],
-      ['Array', [1, 2, 3]]
+      ['Array', [1, 2, 3]],
+      ['pipe char', '|']
     ]),
     [
       '| Type      | Value |',
@@ -39,7 +40,8 @@ test('table()', function (t) {
       '| boolean   | true  |',
       '| undefined |       |',
       '| null      |       |',
-      '| Array     | 1,2,3 |'
+      '| Array     | 1,2,3 |',
+      '| pipe char | \\|   |'
     ].join('\n'),
     'should serialize values'
   )

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ test('table()', function (t) {
       '| undefined |       |',
       '| null      |       |',
       '| Array     | 1,2,3 |',
-      '| pipe char | \\|   |'
+      '| pipe char | \\|    |'
     ].join('\n'),
     'should serialize values'
   )


### PR DESCRIPTION
Allows the usage of the pipe char inside a cell.

For example, having a string with a  |  in it should result in:

`'string with \\|' `
| Example      | 
|------------------|
| string with \| |
