### PR TITLE
Fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -212,7 +212,7 @@ markdownTable(
     ['中文', 'Charlie'],
     ['👩‍❤️‍👩', 'Delta']
   ],
-  {stringLength: width}
+  {stringLength: stringWidth}
 )
 ```
 


### PR DESCRIPTION
Need to use the `stringWidth` imported from `'string-width'`.

Without:
```
ReferenceError: width is not defined
```
