### PR TITLE
fix: use ReadonlyArray type for table parameter / align option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  * @typedef Options
  *   Configuration (optional).
- * @property {string|null|Array<string|null|undefined>} [align]
+ * @property {string|null|ReadonlyArray<string|null|undefined>} [align]
  *   One style for all columns, or styles for their respective columns.
  *   Each style is either `'l'` (left), `'r'` (right), or `'c'` (center).
  *   Other values are treated as `''`, which doesn’t place the colon in the
@@ -146,7 +146,7 @@
 /**
  * Generate a markdown ([GFM](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)) table..
  *
- * @param {Array<Array<string|null|undefined>>} table
+ * @param {ReadonlyArray<ReadonlyArray<string|null|undefined>>} table
  *   Table data (matrix of strings).
  * @param {Options} [options]
  *   Configuration (optional).


### PR DESCRIPTION
This should be a backwards-compatible improvement to the `markdownTable` function parameter/option TypeScript types. In addition to allowing regular (writable/mutable) arrays, the user can now provide read-only arrays. This is possible because markdown-table does not modify these input arrays anyway.

Without this change, someone wanting to pass a read-only array to this function would have to first recreate the array (like `[...arr]`) in order to do so.

Related documentation about the readonly arrays in TypeScript:
* https://mariusschulz.com/blog/read-only-array-and-tuple-types-in-typescript#read-only-array-types-in-typescript
* https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#a-new-syntax-for-readonlyarray