### PR TITLE
Convert linebreaks to <br/>

### DIFF
--- a/index.js
+++ b/index.js
@@ -352,7 +352,9 @@ export function markdownTable(table, options = {}) {
  * @returns {string}
  */
 function serialize(value) {
-  return value === null || value === undefined ? '' : String(value)
+  return value === null || value === undefined
+    ? ''
+    : String(value).replace(/\n/g, '<br/>')
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -285,6 +285,21 @@ test('markdownTable()', () => {
     ].join('\n'),
     'should use `stringLength` to detect cell lengths'
   )
+
+  assert.equal(
+    markdownTable([
+      ['A', 'B'],
+      ['Single', 'This is a single line'],
+      ['Multiple', 'This one\nspreads over\nmultiple lines']
+    ]),
+    [
+      '| A        | B                                            |',
+      '| -------- | -------------------------------------------- |',
+      '| Single   | This is a single line                        |',
+      '| Multiple | This one<br/>spreads over<br/>multiple lines |'
+    ].join('\n'),
+    'should convert line breaks'
+  )
 })
 
 /**


### PR DESCRIPTION
I considered wrapping this in an option to preserve BC, but the current output is broken when cell content contains linebreaks: 

```
| A        | B                                    |
| -------- | ------------------------------------ |
| Single   | This is a single line                |
| Multiple | This one
spreads over
multiple lines | 
```