### PR TITLE
Allow more permissive cell types, Number, Buffer, etc. as long as the object passed in implements a `toString()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,10 +144,16 @@
  */
 
 /**
+ * @typedef Stringer
+ *   Any value that has a `.toString()` method.
+ * @property {() => string} toString
+ */
+
+/**
  * Generate a markdown ([GFM](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables)) table..
  *
- * @param {ReadonlyArray<ReadonlyArray<string|null|undefined>>} table
- *   Table data (matrix of strings).
+ * @param {ReadonlyArray<ReadonlyArray<Stringer|null|undefined>>} table
+ *   Table data (matrix of strings or values with a `toString` method).
  * @param {Options} [options]
  *   Configuration (optional).
  * @returns {string}
@@ -348,7 +354,7 @@ export function markdownTable(table, options = {}) {
 }
 
 /**
- * @param {string|null|undefined} [value]
+ * @param {Stringer|null|undefined} [value]
  * @returns {string}
  */
 function serialize(value) {

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,9 @@ There is no default export.
 
 ### `markdownTable(table[, options])`
 
-Generate a markdown table from table data (matrix of strings).
+Generate a markdown table from table data (matrix of strings).  Non-string
+values will be coerced to strings via the
+[String constructor][string-constructor].
 
 ##### `options`
 
@@ -342,3 +344,5 @@ See [How to Contribute to Open Source][contribute].
 [mdast-util-to-markdown]: https://github.com/syntax-tree/mdast-util-to-markdown
 
 [mdast-util-gfm]: https://github.com/syntax-tree/mdast-util-gfm
+
+[string-constructor]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String


### PR DESCRIPTION
Closes #32 